### PR TITLE
Fix _call() method failing

### DIFF
--- a/src/Chargify/Controller/Factory.php
+++ b/src/Chargify/Controller/Factory.php
@@ -26,7 +26,7 @@ class Factory
    * @param string $name name of method
    * @return Chargify\Controller
    */
-  public function __call($name)
+  public function __call($name, $args)
   {
     return self::build($name, $this->domain, $this->api_key);
   }


### PR DESCRIPTION
Fix for Fatal error: Method Chargify\Controller\Factory::__call() must take exactly 2 arguments